### PR TITLE
Add metadata field to TestRunEndEventRequest for context

### DIFF
--- a/testsystem/v1/events/events.proto
+++ b/testsystem/v1/events/events.proto
@@ -89,4 +89,5 @@ message TestRunEndEventRequest {
   testsystem.v1.common.TestStatus final_status = 2;
   google.protobuf.Timestamp start_time = 3;
   google.protobuf.Duration duration = 4;
+  map<string, string> metadata = 5;
 }


### PR DESCRIPTION
This pull request adds support for including additional metadata in the `TestRunEndEventRequest` message. This allows arbitrary key-value pairs to be attached to test run end events.

Event schema enhancement:

* Added a `metadata` field of type `map<string, string>` to the `TestRunEndEventRequest` message in `event.proto` to allow attaching arbitrary metadata to test run end events.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the ability to attach custom metadata to test run completion events, enabling additional context to be included when reporting test results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->