### PR TITLE
Add attachments field to StepRun message for documentation

### DIFF
--- a/testsystem/v1/entities/test_case.proto
+++ b/testsystem/v1/entities/test_case.proto
@@ -50,4 +50,5 @@ message StepRun {
     string location = 15; // Location in the code where the step is defined
     string category = 16; // Category of step (e.g., "hook", "fixture", "test.step")
     int32 retry_index = 17; // Current retry attempt index of the parent test case
+    repeated testsystem.v1.common.Attachment attachments = 18; // Attachments related to the step result
 }


### PR DESCRIPTION
This pull request adds support for attachments to test step results in the protocol buffer definition for test cases. This enhancement allows each `StepRun` to include a list of attachments, such as logs or screenshots, which can be useful for debugging and reporting.

Enhancement to test step results:

* Added a new `attachments` field to the `StepRun` message in `test_case.proto`, allowing each test step to include multiple attachments related to its result.