### PR TITLE
Add execution_id field for tracking test executions

### DIFF
--- a/testsystem/v1/entities/test_case.proto
+++ b/testsystem/v1/entities/test_case.proto
@@ -52,5 +52,5 @@ message StepRun {
     string category = 16; // Category of step (e.g., "hook", "fixture", "test.step")
     int32 retry_index = 17; // Current retry attempt index of the parent test case
     repeated testsystem.v1.common.Attachment attachments = 18; // Attachments related to the step result
-    string execution_id = 19; // Identifier for the specific execution instance of this test case (useful for parallel runs)
+    string execution_id = 19; // Identifier for the specific execution instance of the parent test case run this step belongs to (useful for parallel runs)
 }

--- a/testsystem/v1/entities/test_case.proto
+++ b/testsystem/v1/entities/test_case.proto
@@ -30,6 +30,7 @@ message TestCaseRun {
     int32 retry_count = 17; // Total number of retry attempts allowed for this test
     int32 retry_index = 18; // Current retry attempt index (0 for first attempt)
     int32 timeout = 19; // Timeout in milliseconds for this test
+    string execution_id = 20; // Identifier for the specific execution instance of this test case (useful for parallel runs)
 }
 
 message StepRun {
@@ -51,4 +52,5 @@ message StepRun {
     string category = 16; // Category of step (e.g., "hook", "fixture", "test.step")
     int32 retry_index = 17; // Current retry attempt index of the parent test case
     repeated testsystem.v1.common.Attachment attachments = 18; // Attachments related to the step result
+    string execution_id = 19; // Identifier for the specific execution instance of this test case (useful for parallel runs)
 }

--- a/testsystem/v1/entities/test_suite.proto
+++ b/testsystem/v1/entities/test_suite.proto
@@ -32,6 +32,7 @@ message TestSuiteRun {
     string owner = 18; // Team or individual responsible for the test suite
     repeated testsystem.v1.entities.TestCaseRun test_cases = 19; // Nested test case objects (optional, for sending full structure)
     repeated TestSuiteRun sub_suites = 20; // Nested test suite objects (optional, for sending full structure)
+    string execution_id = 21; // Identifier for the specific execution instance of this test case (useful for parallel runs)
 }
 
 enum SuiteType {

--- a/testsystem/v1/entities/test_suite.proto
+++ b/testsystem/v1/entities/test_suite.proto
@@ -32,7 +32,7 @@ message TestSuiteRun {
     string owner = 18; // Team or individual responsible for the test suite
     repeated testsystem.v1.entities.TestCaseRun test_cases = 19; // Nested test case objects (optional, for sending full structure)
     repeated TestSuiteRun sub_suites = 20; // Nested test suite objects (optional, for sending full structure)
-    string execution_id = 21; // Identifier for the specific execution instance of this test case (useful for parallel runs)
+    string execution_id = 21; // Identifier for the specific execution instance of this test suite run (useful for parallel runs)
 }
 
 enum SuiteType {

--- a/testsystem/v1/events/events.proto
+++ b/testsystem/v1/events/events.proto
@@ -86,7 +86,7 @@ message ReportRunStartEventRequest {
   int32 total_tests = 3;
   string name = 4;
   map<string, string> metadata = 5;
-  string execution_id = 6; // Identifier for the specific execution instance of this test case (useful for parallel runs)
+  string execution_id = 6; // Identifier for the specific execution instance of this run (useful for parallel runs)
 }
 
 message TestRunEndEventRequest {
@@ -95,5 +95,5 @@ message TestRunEndEventRequest {
   google.protobuf.Timestamp start_time = 3;
   google.protobuf.Duration duration = 4;
   map<string, string> metadata = 5;
-  string execution_id = 6; // Identifier for the specific execution instance of this test case (useful for parallel runs)
+  string execution_id = 6; // Identifier for the specific execution instance of this test run (useful for parallel runs)
 }

--- a/testsystem/v1/events/events.proto
+++ b/testsystem/v1/events/events.proto
@@ -36,6 +36,7 @@ message TestFailureEventRequest {
   repeated testsystem.v1.common.Attachment attachments = 5;
   string run_id = 6;
   int32 retry_index = 7;
+  string execution_id = 8; // Identifier for the specific execution instance of this test case (useful for parallel runs)
 }
 message TestErrorEventRequest {
   string test_id = 1;
@@ -45,6 +46,7 @@ message TestErrorEventRequest {
   repeated testsystem.v1.common.Attachment attachments = 5;
   string run_id = 6;
   int32 retry_index = 7;
+  string execution_id = 8; // Identifier for the specific execution instance of this test case (useful for parallel runs)
 }
 
 message StdErrorEventRequest {
@@ -54,6 +56,7 @@ message StdErrorEventRequest {
   string test_case_run_id = 4; // Reference to the specific test case run
   string run_id = 5;
   int32 retry_index = 6;
+  string execution_id = 7; // Identifier for the specific execution instance of this test case (useful for parallel runs)
 }
 message StdOutputEventRequest {
   string test_id = 1;
@@ -62,6 +65,7 @@ message StdOutputEventRequest {
   string test_case_run_id = 4; // Reference to the specific test case run
   string run_id = 5;
   int32 retry_index = 6;
+  string execution_id = 7; // Identifier for the specific execution instance of this test case (useful for parallel runs)
 }
 
 message SuiteBeginEventRequest {
@@ -82,6 +86,7 @@ message ReportRunStartEventRequest {
   int32 total_tests = 3;
   string name = 4;
   map<string, string> metadata = 5;
+  string execution_id = 6; // Identifier for the specific execution instance of this test case (useful for parallel runs)
 }
 
 message TestRunEndEventRequest {
@@ -90,4 +95,5 @@ message TestRunEndEventRequest {
   google.protobuf.Timestamp start_time = 3;
   google.protobuf.Duration duration = 4;
   map<string, string> metadata = 5;
+  string execution_id = 6; // Identifier for the specific execution instance of this test case (useful for parallel runs)
 }


### PR DESCRIPTION
Introduce an `execution_id` field in various message types to enable tracking of specific execution instances for test cases and steps, enhancing support for parallel test runs.